### PR TITLE
game-state-service: don't defer the reset

### DIFF
--- a/game-state-service
+++ b/game-state-service
@@ -91,6 +91,7 @@ class GameState(object):
     def reset(self):
         self._state = Json.Object()
         self._save_deferred()
+        self.flush()
 
     def flush(self):
         # If there is no pending save, return.


### PR DESCRIPTION
A dbus call to reset should not return back before the empty state is
stored. Otherwise the scripts calling it have a race condition.

https://phabricator.endlessm.com/T24972