### PR TITLE
Add appdata

### DIFF
--- a/data/com.endlessm.GameStateService.appdata.xml
+++ b/data/com.endlessm.GameStateService.appdata.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>com.endlessm.GameStateService.desktop</id>
+  <name>Game State Service</name>
+  <summary>Global state for all Hack related affairs</summary>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LGPL-2.1</project_license>
+</component>

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,4 @@
+install_data(
+    'com.endlessm.GameStateService.appdata.xml',
+    install_dir: join_paths(data_dir, 'appdata')
+)

--- a/meson.build
+++ b/meson.build
@@ -23,12 +23,17 @@ install_data(
     install_dir: get_option('bindir')
 )
 
+data_dir = join_paths(get_option('prefix'), get_option('datadir'))
+
+subdir('data')
+
 message('\n'.join([
     '@0@ @1@'.format(meson.project_name(), meson.project_version()),
     '--------------------------------------',
     'Directories:',
     '    prefix: @0@'.format(get_option('prefix')),
     '    bindir: @0@'.format(get_option('bindir')),
+    '    datadir: @0@'.format(data_dir),
     '    session_bus_services_dir: @0@'.format(session_bus_services_dir),
     ''
 ]))


### PR DESCRIPTION
GNOME Software relies heavily on the AppStream/appdata for managing
apps, so we make sure that the GameStateService has the appdata.

https://phabricator.endlessm.com/T26020