### PR TITLE
T26744 CLI

### DIFF
--- a/game-state-service
+++ b/game-state-service
@@ -111,6 +111,8 @@ class GameState(object):
 class GameStateService(Gio.Application):
 
     _DBUS_NAME = 'com.endlessm.GameStateService'
+    _DBUS_IFACE = 'com.endlessm.GameStateService'
+    _DBUS_PATH = '/com/endlessm/GameStateService'
     _DBUS_KEY_ERROR = 'com.endlessm.GameStateService.KeyError'
     _DBUS_XML = '''
     <node>
@@ -188,13 +190,19 @@ class GameStateService(Gio.Application):
             else:
                 invocation.return_value(GLib.Variant('(v)', (value,)))
         elif method == 'Reload':
-            self._state.reload()
-            connection.emit_signal(None, path, iface, 'reload', None)
+            self._reload()
             invocation.return_value(None)
         elif method == 'Reset':
             self._state.reset()
             connection.emit_signal(None, path, iface, 'reset', None)
             invocation.return_value(None)
+
+    def _reload(self):
+        print('Reloading the state')
+        self._state.reload()
+        self.get_dbus_connection().emit_signal(None, self._DBUS_PATH,
+                                               self._DBUS_IFACE,
+                                               'reload', None)
 
     def do_dbus_register(self, connection, path):
         info = Gio.DBusNodeInfo.new_for_xml(self._DBUS_XML)

--- a/game-state-service
+++ b/game-state-service
@@ -2,6 +2,8 @@
 
 import gi
 import logging
+import sys
+
 gi.require_version('GLib', '2.0')  # noqa
 gi.require_version('Json', '1.0')  # noqa
 from gi.repository import Gio
@@ -146,10 +148,14 @@ class GameStateService(Gio.Application):
     def __init__(self):
         super().__init__(application_id=self._DBUS_NAME,
                          inactivity_timeout=self._INACTIVITY_TIMEOUT,
-                         flags=Gio.ApplicationFlags.IS_SERVICE)
+                         flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE)
         self._dbus_id = None
         self._state = None
 
+        self.add_main_option('reload', ord('r'),
+                             GLib.OptionFlags.NONE, GLib.OptionArg.NONE,
+                             'Reload the current GSS file (do this if the '
+                             'file has been overwritten manually).', None)
 
     def _on_method_called(self, connection, sender, path, iface,
                           method, params, invocation):
@@ -232,7 +238,15 @@ class GameStateService(Gio.Application):
         self._state.flush()
         Gio.Application.do_shutdown(self)
 
+    def do_command_line(self, command_line):
+        options = command_line.get_options_dict()
+
+        if options.contains('reload'):
+            self._reload()
+
+        return 0
+
 
 if __name__ == '__main__':
     service = GameStateService()
-    service.run(None)
+    service.run(sys.argv)

--- a/game-state-service
+++ b/game-state-service
@@ -148,10 +148,6 @@ class GameStateService(Gio.Application):
         self._dbus_id = None
         self._state = None
 
-        # Call hold/release here, so the inactivity-timeout is used correctly
-        # (as the overridden value is only used after a release call).
-        self.hold()
-        self.release()
 
     def _on_method_called(self, connection, sender, path, iface,
                           method, params, invocation):
@@ -216,6 +212,12 @@ class GameStateService(Gio.Application):
 
     def do_startup(self):
         self._state = GameState()
+
+        # Call hold/release here, so the inactivity-timeout is used correctly
+        # (as the overridden value is only used after a release call).
+        self.hold()
+        self.release()
+
         Gio.Application.do_startup(self)
 
     def do_shutdown(self):


### PR DESCRIPTION
I have added the CLI implementation with the `--reload` option for now.

I didn't expect to have to switch from a `SERVICE` type app to a normal one (see last commit which explains why) but I don't think this has any implication in how the GSS behaves normally (apart from allowing secondary instances, that is).

https://phabricator.endlessm.com/T26744