### PR TITLE
Deploy Hack2: rename game state service

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Simply put, it's the player's save-file. More precisely, is a central service th
 The state-file is just a plain-text file. Progression metadata is stored in this file using the JSON format, in order to keep it human-readable. By default, this file will be located at:
 
 ```
-~/.var/app/com.endlessm.GameStateService/data/state.json
+~/.var/app/com.hack_computer.GameStateService/data/state.json
 ```
 
 As mentioned above, the contents of this `state.json` file are objects serialized with the JSON format. See the following example:
@@ -42,11 +42,11 @@ The GameStateService exposes the API consumed by other components of the desktop
 ```javascript
 const {Gio} = imports.gi;
 
-const BusName = 'com.endlessm.GameStateService';
-const BusPath = '/com/endlessm/GameStateService';
+const BusName = 'com.hack_computer.GameStateService';
+const BusPath = '/com/hack_computer/GameStateService';
 const BusIface = `
 <node>
-  <interface name='com.endlessm.GameStateService'>
+  <interface name='com.hack_computer.GameStateService'>
     <method name='Set'>
       <arg type='s' name='key' direction='in'/>
       <arg type='v' name='value' direction='in'/>

--- a/com.hack_computer.GameStateService.json.in
+++ b/com.hack_computer.GameStateService.json.in
@@ -1,12 +1,12 @@
 {
-    "app-id": "com.endlessm.GameStateService",
+    "app-id": "com.hack_computer.GameStateService",
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.30",
     "sdk": "org.gnome.Sdk",
     "finish-args": [
         "--share=ipc",
         "--socket=session-bus",
-        "--own-name=com.endlessm.GameStateService"
+        "--own-name=com.hack_computer.GameStateService"
     ],
     "modules": [
         {

--- a/com.hack_computer.GameStateService.service.in
+++ b/com.hack_computer.GameStateService.service.in
@@ -1,3 +1,3 @@
 [D-BUS Service]
-Name=com.endlessm.GameStateService
+Name=com.hack_computer.GameStateService
 Exec=@bindir@/game-state-service

--- a/data/com.hack_computer.GameStateService.appdata.xml
+++ b/data/com.hack_computer.GameStateService.appdata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
-  <id>com.endlessm.GameStateService.desktop</id>
+  <id>com.hack_computer.GameStateService.desktop</id>
   <name>Game State Service</name>
   <summary>Global state for all Hack related affairs</summary>
   <metadata_license>CC0-1.0</metadata_license>

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,4 +1,4 @@
 install_data(
-    'com.endlessm.GameStateService.appdata.xml',
+    'com.hack_computer.GameStateService.appdata.xml',
     install_dir: join_paths(data_dir, 'appdata')
 )

--- a/examples.py
+++ b/examples.py
@@ -32,9 +32,9 @@ _samples = {
 _proxy = Gio.DBusProxy.new_sync(Gio.bus_get_sync(Gio.BusType.SESSION, None),
                                 0,
                                 None,
-                                'com.endlessm.GameStateService',
-                                '/com/endlessm/GameStateService',
-                                'com.endlessm.GameStateService',
+                                'com.hack_computer.GameStateService',
+                                '/com/hack_computer/GameStateService',
+                                'com.hack_computer.GameStateService',
                                 None)
 
 

--- a/game-state-service
+++ b/game-state-service
@@ -112,13 +112,13 @@ class GameState(object):
 
 class GameStateService(Gio.Application):
 
-    _DBUS_NAME = 'com.endlessm.GameStateService'
-    _DBUS_IFACE = 'com.endlessm.GameStateService'
-    _DBUS_PATH = '/com/endlessm/GameStateService'
-    _DBUS_KEY_ERROR = 'com.endlessm.GameStateService.KeyError'
+    _DBUS_NAME = 'com.hack_computer.GameStateService'
+    _DBUS_IFACE = 'com.hack_computer.GameStateService'
+    _DBUS_PATH = '/com/hack_computer/GameStateService'
+    _DBUS_KEY_ERROR = 'com.hack_computer.GameStateService.KeyError'
     _DBUS_XML = '''
     <node>
-      <interface name='com.endlessm.GameStateService'>
+      <interface name='com.hack_computer.GameStateService'>
         <method name='Get'>
           <arg type='s' name='key' direction='in'/>
           <arg type='v' name='value' direction='out'/>

--- a/meson.build
+++ b/meson.build
@@ -11,8 +11,8 @@ conf = configuration_data()
 conf.set('bindir', join_paths(get_option('prefix'), get_option('bindir')))
 
 configure_file(
-    input: 'com.endlessm.GameStateService.service.in',
-    output: 'com.endlessm.GameStateService.service',
+    input: 'com.hack_computer.GameStateService.service.in',
+    output: 'com.hack_computer.GameStateService.service',
     install: true,
     install_dir: session_bus_services_dir,
     configuration: conf

--- a/tools/build-local-flatpak.sh
+++ b/tools/build-local-flatpak.sh
@@ -19,10 +19,10 @@ GIT_CLONE_BRANCH=${GIT_CLONE_BRANCH:-'", "type": "dir'}
 REPO=${REPO:-repo}
 
 sed -e "s|@GIT_CLONE_BRANCH@|${GIT_CLONE_BRANCH}|g" \
-    com.endlessm.GameStateService.json.in > com.endlessm.GameStateService.json
+    com.hack_computer.GameStateService.json.in > com.hack_computer.GameStateService.json
 
 # Add any extra options from the user to the flatpak-builder command (e.g. --install)
-flatpak-builder build --user --force-clean com.endlessm.GameStateService.json --repo=${REPO} $@ || ret=$?
+flatpak-builder build --user --force-clean com.hack_computer.GameStateService.json --repo=${REPO} $@ || ret=$?
 
 popd
 


### PR DESCRIPTION
This will help to separate the two services when we migrate existing users.

https://phabricator.endlessm.com/T27400